### PR TITLE
polkadot-launch specific Dockerfile; rm basePath from config

### DIFF
--- a/scripts/polkadot-launch/Dockerfile
+++ b/scripts/polkadot-launch/Dockerfile
@@ -1,0 +1,19 @@
+FROM samelamin/imbue AS imbue
+
+LABEL maintainer="imbue-dev"
+
+FROM node:16-slim
+ARG APT_PACKAGES
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update
+RUN apt-get install -y\
+        gnupg2 ca-certificates\
+        ${APT_PACKAGES}
+
+COPY --from=imbue /imbue-collator /
+COPY --from=imbue /polkadot /
+COPY --from=imbue /subkey /
+
+RUN yarn global add polkadot-launch
+
+EXPOSE 30330-30345 9933-9960 8080 3001

--- a/scripts/polkadot-launch/imbueLaunchConfig.js
+++ b/scripts/polkadot-launch/imbueLaunchConfig.js
@@ -1,5 +1,4 @@
-const basePathBase = process.env.POLKADOT_LAUNCH_BASE_PATH_BASE
-    || "/tmp/imbue-polkadot-launch";
+const basePathBase = process.env.POLKADOT_LAUNCH_BASE_PATH_BASE || void 0;
 
 let relaychainBasePort = 30300;
 let relaychainBaseRPCPort = 9900;
@@ -31,14 +30,6 @@ const parachainNodeFlags = [
     "--prometheus-external",
 ];
 
-const executable = (name) => {
-    const envvar = `${name}_executable`.toUpperCase();
-    const exec = process.env[envvar];
-    if (exec) {
-        return exec;
-    }
-    throw new Error(`Missing required envvar: ${envvar}`);
-}
 const relaychain = {
     "bin": "/polkadot",
     chain: "rococo-local",
@@ -48,7 +39,7 @@ const relaychain = {
             wsPort: relaychainBaseWSPort++,
             port: relaychainBasePort++,
             rpcPort: relaychainBaseRPCPort++,
-            basePath: `${basePathBase}/alice-relaychain`,
+            basePath: basePathBase && `${basePathBase}/alice-relaychain`,
             flags: [
                 ...relaychainFlags,
                 "--prometheus-external",
@@ -63,7 +54,7 @@ const relaychain = {
             wsPort: relaychainBaseWSPort + idx,
             rpcPort: relaychainBaseRPCPort + idx,
             port: relaychainBasePort + idx,
-            basePath: `${basePathBase}/${name}-${idx}-relaychain`,
+            basePath: basePathBase && `${basePathBase}/${name}-${idx}-relaychain`,
             flags: [...relaychainFlags]
         }))
     ],
@@ -81,7 +72,7 @@ const imbue_collator = {
             wsPort: parachainBaseWSPort++,
             port: parachainBasePort++,
             rpcPort: parachainBaseRPCPort++,
-            basePath: `${basePathBase}/alice-imbue-collator`,
+            basePath: basePathBase && `${basePathBase}/alice-imbue-collator`,
             flags: [
                 `--prometheus-port=${parachainAlicePrometheusPort}`,
                 ...parachainNodeFlags,
@@ -97,7 +88,7 @@ const imbue_collator = {
             wsPort: parachainBaseWSPort + idx,
             rpcPort: parachainBaseRPCPort + idx,
             port: parachainBasePort + idx,
-            basePath: `${basePathBase}/${name}-${idx}-imbue-collator`,
+            basePath: basePathBase && `${basePathBase}/${name}-${idx}-imbue-collator`,
             flags: parachainNodeFlags,
         }))
     ]


### PR DESCRIPTION
These are the changes I had in mind in my comments on https://github.com/ImbueNetwork/imbue/pull/5 for refactoring the Dockerfile.

This PR would:

- create a small alpine-based image with only the binaries, which could be used without polkadot-launch
- create a second Dockerfile in `scripts/polkadot-launch` that depends on the base imbue image, and adds polkadot-launch to the mix

For me, the images end up looking  like

```bash
imbue-network                 latest    1b0ead9ea8e8   31 minutes ago   666MB
samelamin/imbue               0.9.13    a5d8e2d489b6   2 hours ago      254MB
```
