### PR TITLE
take fee on approval of a milestone

### DIFF
--- a/pallets/proposals/src/benchmarking.rs
+++ b/pallets/proposals/src/benchmarking.rs
@@ -170,7 +170,7 @@ benchmarks! {
         let alice: T::AccountId = create_funded_user::<T>("contributor", 1, 100_000);
         let bob: T::AccountId = create_funded_user::<T>("initiator", 1, 100_000);
 
-        let contribution_amount = 10_000u32;
+        let contribution_amount = 100_000u32;
         let milestone_keys: BoundedMilestoneKeys = vec![0].try_into().unwrap();
 
         // Setup state.
@@ -192,7 +192,7 @@ benchmarks! {
         let alice: T::AccountId = create_funded_user::<T>("contributor", 1, 100_000);
         let bob: T::AccountId = create_funded_user::<T>("initiator", 1, 100_000);
 
-        let contribution_amount = 10_000u32;
+        let contribution_amount = 100_000u32;
         let milestone_keys: BoundedMilestoneKeys = vec![0].try_into().unwrap();
 
         // Setup state.
@@ -233,17 +233,18 @@ benchmarks! {
             Proposals::<T>::vote_on_milestone(RawOrigin::Signed(alice.clone()).into(), 0, key, Some(key + 2u32), true)?;
             Proposals::<T>::finalise_milestone_voting(RawOrigin::Signed(bob.clone()).into(), 0, key)?;
         }
-        
+            let project = Projects::<T>::get(0).unwrap();
+            let withdrawn_wo_fee: BalanceOf<T> = (10_000u32 * milestone_keys.len() as u32).into();
         // (Initiator, ProjectKey)
-    }: _(RawOrigin::Signed(bob.clone()) ,0)
+    }: _(RawOrigin::Signed(bob.clone()), 0)
     verify {
-        assert_last_event::<T>(Event::ProjectFundsWithdrawn(bob, 0, (10_000u32 * milestone_keys.len() as u32).into(), CurrencyId::Native).into());
+        assert_last_event::<T>(Event::ProjectFundsWithdrawn(bob, 0, withdrawn_wo_fee - project.fee_taken, CurrencyId::Native).into());
     }
 
     raise_vote_of_no_confidence { 
         let alice: T::AccountId = create_funded_user::<T>("contributor", 1, 100_000);
         let bob: T::AccountId = create_funded_user::<T>("initiator", 1, 100_000);
-        let contribution_amount = 10_000u32;
+        let contribution_amount = 100_000u32;
         let milestone_keys: BoundedMilestoneKeys = vec![0].try_into().unwrap();
         // Setup state: Approved project.
         create_project_common::<T>(contribution_amount.into());
@@ -354,19 +355,17 @@ benchmarks! {
     }
 
     split_off_refunds {
-        let a in 0..100u32;
+        let a in 0..10_000u32;
         run_to_block::<T>(5u32.into());
         let mut accounts: Vec<T::AccountId> = vec![];
         let mut refunds: Refunds<T> = vec![];
-        for i in 0..100usize {
-            let acc = create_funded_user::<T>("contributor", i as u32, 100_000);
-
-            accounts.push(acc);
+        let acc = create_funded_user::<T>("contributor", 10u32, 100_000);
+        for i in 0..10_000 {
+            accounts.push(acc.clone());
             if i > 0 {
                 refunds.push((accounts[0].clone(), accounts[i].clone(), 10_000u32.into(), CurrencyId::Native));
             }
         }
-        
     }: {
         //(Refunds, SplitOffIndex)
         Proposals::<T>::split_off_refunds(&mut refunds, a.into())

--- a/pallets/proposals/src/impls.rs
+++ b/pallets/proposals/src/impls.rs
@@ -521,9 +521,15 @@ impl<T: Config> Pallet<T> {
         for (who, contribution) in project.contributions.iter() {
             let project_account_id = Self::project_account_id(project_key);
             
-            // is 0/100 ok? if this is called when all milestones are approved. the locked milestone percent will be zero.
+            if project.fee_taken > BalanceOf::<T>::default() {
+                locked_milestone_percentage.saturating_sub(T::PercentFeeOnApproval::get() as u32);                
+            }
+
+            // Ensure that the locked milestone percentage > 0
+           // ensure!(todo!());
+
             let refund_amount: BalanceOf<T> = 
-                ((contribution).value * (locked_milestone_percentage.saturating_sub(T::PercentFeeOnApproval::get() as u32)).into())
+                ((contribution).value * (locked_milestone_percentage).into())
                 / MAX_PERCENTAGE.into();
 
             current_refunds.push((who.clone(), project_account_id.clone(), refund_amount, project.currency_id));

--- a/pallets/proposals/src/impls.rs
+++ b/pallets/proposals/src/impls.rs
@@ -509,6 +509,8 @@ impl<T: Config> Pallet<T> {
 
 
     /// Appends a list of refunds to the queue to be used by the hooks.
+    /// It will tally up the required refund for each contribution as a fraction of UNAPPROVED milestones.
+    /// If a milestone has been approved then the funds WILL NOT be refunded. 
     pub fn add_refunds_to_queue(project_key: ProjectKey) -> DispatchResultWithPostInfo {
         let mut project = Projects::<T>::get(&project_key).ok_or(Error::<T>::ProjectDoesNotExist)?;
 
@@ -527,10 +529,6 @@ impl<T: Config> Pallet<T> {
         for (who, contribution) in project.contributions.iter() {
             let project_account_id = Self::project_account_id(project_key);
             
-            if project.fee_taken > BalanceOf::<T>::default() {
-                locked_milestone_percentage = locked_milestone_percentage.saturating_sub(T::PercentFeeOnApproval::get() as u32);                
-            }
-
             let refund_amount: BalanceOf<T> = 
                 ((contribution).value * (locked_milestone_percentage).into())
                 / MAX_PERCENTAGE.into();

--- a/pallets/proposals/src/impls.rs
+++ b/pallets/proposals/src/impls.rs
@@ -282,13 +282,14 @@ impl<T: Config> Pallet<T> {
 
                     Ok::<(), Error<T>>(())
                 })?;
-                let fee = take_fee_from_pot(project_key, T::PercentFeeOnApproval::get(), )
+
+                let fee = Self::take_fee_from_pot(project_key, T::PercentFeeOnApproval::get(), total_contribution_amount / milestone.percentage_to_unlock.into(), project.currency_id)?;
 
                 // Take the fee and remove from avaliable funds.
-                project.fee_taken = fee;
+                project.fee_taken += fee;
                 project.withdrawn_funds += fee;
 
-                project.milestones.insert(milestone_key, milestone.clone());
+                project.milestones.insert(milestone_key, milestone);
 
                 Self::deposit_event(Event::MilestoneApproved(
                     project.initiator.clone(),
@@ -529,9 +530,6 @@ impl<T: Config> Pallet<T> {
             if project.fee_taken > BalanceOf::<T>::default() {
                 locked_milestone_percentage = locked_milestone_percentage.saturating_sub(T::PercentFeeOnApproval::get() as u32);                
             }
-
-            // Ensure that the locked milestone percentage > 0
-           // ensure!(todo!());
 
             let refund_amount: BalanceOf<T> = 
                 ((contribution).value * (locked_milestone_percentage).into())

--- a/pallets/proposals/src/impls.rs
+++ b/pallets/proposals/src/impls.rs
@@ -283,7 +283,8 @@ impl<T: Config> Pallet<T> {
                     Ok::<(), Error<T>>(())
                 })?;
 
-                let fee = Self::take_fee_from_pot(project_key, T::PercentFeeOnApproval::get(), total_contribution_amount / milestone.percentage_to_unlock.into(), project.currency_id)?;
+                let total_to_be_feed = total_contribution_amount * milestone.percentage_to_unlock.into() / 100u32.into();
+                let fee = Self::take_fee_from_pot(project_key, T::PercentFeeOnApproval::get(), total_to_be_feed, project.currency_id)?;
 
                 // Take the fee and remove from avaliable funds.
                 project.fee_taken += fee;

--- a/pallets/proposals/src/impls.rs
+++ b/pallets/proposals/src/impls.rs
@@ -460,7 +460,7 @@ impl<T: Config> Pallet<T> {
         ensure!(!project.cancelled, Error::<T>::ProjectWithdrawn);
         ensure!(who == project.initiator, Error::<T>::InvalidAccount);
         
-        let total_unapproved_funds: BalanceOf<T> = project.raised_funds;
+        let total_unapproved_funds: BalanceOf<T> = project.raised_funds.saturating_sub(project.withdrawn_funds);
 
         let mut unlocked_funds: BalanceOf<T> = (0_u32).into();
         for (_milestone_key, milestone) in project.milestones.clone() {
@@ -471,7 +471,7 @@ impl<T: Config> Pallet<T> {
             }
         }
 
-        let available_funds: BalanceOf<T> = unlocked_funds.saturating_sub(project.withdrawn_funds);
+        let available_funds: BalanceOf<T> = unlocked_funds;//.saturating_sub(project.withdrawn_funds);
         ensure!(
             available_funds > (0_u32).into(),
             Error::<T>::NoAvailableFundsToWithdraw
@@ -522,7 +522,7 @@ impl<T: Config> Pallet<T> {
             let project_account_id = Self::project_account_id(project_key);
             
             if project.fee_taken > BalanceOf::<T>::default() {
-                locked_milestone_percentage.saturating_sub(T::PercentFeeOnApproval::get() as u32);                
+                locked_milestone_percentage = locked_milestone_percentage.saturating_sub(T::PercentFeeOnApproval::get() as u32);                
             }
 
             // Ensure that the locked milestone percentage > 0
@@ -702,7 +702,7 @@ impl<T: Config> Pallet<T> {
         // The nay vote must >= minimum threshold required for the vote to pass.
         let total_contribute = project.raised_funds;
 
-        // 100 * Threshold =  (total_contribute * majority_required)/100
+        // 100 * Threshold =  (total_contribute * majority_required)
         let threshold_votes: BalanceOf<T> = total_contribute * majority_required.into();
 
         if vote.nay * 100u8.into() >= threshold_votes {

--- a/pallets/proposals/src/lib.rs
+++ b/pallets/proposals/src/lib.rs
@@ -97,6 +97,7 @@ pub mod pallet {
 
         /// The treasury account.
         type TreasuryId: Get<<Self as frame_system::Config>::AccountId>;
+        
         /// Maximum number of contributors per project.
         type MaximumContributorsPerProject: Get<u32>;
 

--- a/pallets/proposals/src/lib.rs
+++ b/pallets/proposals/src/lib.rs
@@ -444,6 +444,8 @@ pub mod pallet {
                 Error::<T>::MilestonesTotalPercentageMustEqual100
             );
 
+            // Ensure that the fee taken is above the existential deposit.
+
             Self::new_project(
                 who,
                 name,
@@ -848,6 +850,7 @@ pub struct Project<AccountId, Balance, BlockNumber, Timestamp> {
     approved_for_funding: bool,
     funding_threshold_met: bool,
     cancelled: bool,
+    fee_taken: Balance
 }
 
 /// The contribution users made to a proposal project.

--- a/pallets/proposals/src/lib.rs
+++ b/pallets/proposals/src/lib.rs
@@ -90,6 +90,12 @@ pub mod pallet {
 
         /// The minimum percentage of votes, inclusive, that is required for a vote to pass.  
         type PercentRequiredForVoteToPass: Get<u8>;
+
+        /// The % of fee taken on the approval of a project
+        type PercentFeeOnApproval: Get<u8>;
+
+        /// The treasury account.
+        type TreasuryId: Get<<Self as frame_system::Config>::AccountId>;
     }
 
     #[pallet::type_value]

--- a/pallets/proposals/src/lib.rs
+++ b/pallets/proposals/src/lib.rs
@@ -331,9 +331,9 @@ pub mod pallet {
     impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {
         fn on_runtime_upgrade() -> Weight {
             let mut weight = T::DbWeight::get().reads_writes(1, 1);
-            if StorageVersion::<T>::get() == Release::V0 {
-                weight += migration::v1::migrate::<T>();
-                StorageVersion::<T>::set(Release::V1);
+            if StorageVersion::<T>::get() == Release::V1 {
+                weight += migration::v2::migrate::<T>();
+                StorageVersion::<T>::set(Release::V2);
             }
             weight
         }

--- a/pallets/proposals/src/lib.rs
+++ b/pallets/proposals/src/lib.rs
@@ -322,6 +322,8 @@ pub mod pallet {
         VoteThresholdNotMet,
         /// The project must be approved.
         ProjectApprovalRequired,
+        /// A milestone cannot be approved more than once.
+        MilestoneAlreadyApproved,
     }
 
     #[pallet::hooks]

--- a/pallets/proposals/src/migration.rs
+++ b/pallets/proposals/src/migration.rs
@@ -98,6 +98,11 @@ pub mod v1 {
                 funding_threshold_met: project.funding_threshold_met,
                 cancelled: project.cancelled,
                 raised_funds: raised_funds,
+
+
+                //TODOOO
+                fee_taken: 0u32.into(),
+
             };
             Some(migrated_project)
         });

--- a/pallets/proposals/src/mock.rs
+++ b/pallets/proposals/src/mock.rs
@@ -207,7 +207,11 @@ parameter_types! {
     pub const ProposalsPalletId: PalletId = PalletId(*b"imbgrant");
     pub NoConfidenceTimeLimit: BlockNumber = 100800u32.into();
     pub PercentRequiredForVoteToPass: u8 = 75u8;
+    pub TreasuryAccount: AccountId = PalletId(*b"py/trsry").into_account_truncating();
+    pub const PercentFeeOnApproval: u8 = 3;
+
 }
+
 impl proposals::Config for Test {
     type Event = Event;
     type PalletId = ProposalsPalletId;
@@ -219,6 +223,8 @@ impl proposals::Config for Test {
     type MaxWithdrawalExpiration = TwoWeekBlockUnit;
     type NoConfidenceTimeLimit = NoConfidenceTimeLimit;
     type PercentRequiredForVoteToPass = PercentRequiredForVoteToPass;
+    type TreasuryId = TreasuryAccount;
+    type PercentFeeOnApproval = PercentFeeOnApproval;
 }
 
 parameter_types! {

--- a/pallets/proposals/src/mock.rs
+++ b/pallets/proposals/src/mock.rs
@@ -282,6 +282,11 @@ pub fn build_test_externality() -> sp_io::TestExternalities {
         .build_storage::<Test>()
         .unwrap();
     let mut ext = sp_io::TestExternalities::new(t);
-    ext.execute_with(|| System::set_block_number(1));
+    ext.execute_with(|| {
+        System::set_block_number(1);
+        let tres = <Test as proposals::Config>::TreasuryId::get();
+        let _ = Currencies::deposit(CurrencyId::Native, &tres, 100_000u64);
+    }
+    );
     ext
 }

--- a/pallets/proposals/src/tests.rs
+++ b/pallets/proposals/src/tests.rs
@@ -1758,8 +1758,8 @@ fn withdraw_percentage_milestone_completed_refund_locked_milestone() {
     let alice = get_account_id_from_seed::<sr25519::Public>("Alice");
     let bob = get_account_id_from_seed::<sr25519::Public>("Bob");
     let charlie = get_account_id_from_seed::<sr25519::Public>("Charlie");
-    let additional_amount = 10000000u64;
-    let required_funds = 1000000u64;
+    let additional_amount = 10_000_000u64;
+    let required_funds = 1_000_000u64;
     let project_key = 0;
 
     let mut proposed_milestones: Vec<ProposedMilestone> = Vec::new();
@@ -1886,7 +1886,7 @@ fn withdraw_percentage_milestone_completed_refund_locked_milestone() {
             mock::Event::from(proposals::Event::ProjectFundsWithdrawn(
                 alice,
                 project_key,
-                200000u64,
+                200000u64 - project.fee_taken,
                 CurrencyId::Native
             ))
         );
@@ -1909,7 +1909,7 @@ fn withdraw_percentage_milestone_completed_refund_locked_milestone() {
             exp_projectfundsrefunded_event,
             mock::Event::from(proposals::Event::ProjectFundsAddedToRefundQueue(
                 project_key,
-                800000u64
+                800000u64 - projesct.fee_taken
             ))
         );
 
@@ -1993,9 +1993,10 @@ fn test_raising_a_vote_of_no_confidence() {
         let round_count = RoundCount::<Test>::get();
 
         // Assert that storage has been mutated correctly.
-        assert!(vote.nay == 1_000_000u64 && vote.yay == 0u64);
-        assert!(UserVotes::<Test>::get((bob, project_key, 0, round_count)) == Some(true));
-        assert!(round_count == 2u32);
+        assert_eq!(vote.nay, 1_000_000u64);
+        assert_eq!(vote.yay, 0u64);
+        assert_eq!(UserVotes::<Test>::get((bob, project_key, 0, round_count)), Some(true));
+        assert_eq!(round_count, 2u32);
         assert!(NoConfidenceVotes::<Test>::contains_key(project_key));
 
         // Assert that you cannot raise the vote twice.
@@ -2073,11 +2074,12 @@ fn test_adding_vote_of_no_confidence() {
         let round_count = RoundCount::<Test>::get();
 
         // Assert that storage has been mutated correctly.
-        assert!(vote.nay == 500_000u64 && vote.yay == 500_000u64);
-        assert!(UserVotes::<Test>::get((charlie, project_key, 0, round_count)) == Some(true));
-        assert!(UserVotes::<Test>::get((bob, project_key, 0, round_count)) == Some(true));
+        assert_eq!(vote.nay, 500_000u64);
+        assert_eq!(vote.yay, 500_000u64);
+        assert_eq!(UserVotes::<Test>::get((charlie, project_key, 0, round_count)), Some(true));
+        assert_eq!(UserVotes::<Test>::get((bob, project_key, 0, round_count)), Some(true));
 
-        assert!(round_count == 2u32);
+        assert_eq!(round_count, 2u32);
     });
 }
 
@@ -2296,7 +2298,7 @@ fn test_refunds_go_back_to_contributors() {
             assert_eq!(Currencies::free_balance(CurrencyId::Native, &accounts[i as usize]), 20_000u64);
         }
 
-        assert!(Currencies::free_balance(CurrencyId::Native, &Proposals::project_account_id(0)) == 0u64)
+        assert_eq!(Currencies::free_balance(CurrencyId::Native, &Proposals::project_account_id(0)), 0u64);
     });
 } 
 
@@ -2348,7 +2350,7 @@ fn test_refunds_state_is_handled_correctly() {
            assert_eq!(RefundQueue::<Test>::get().len(), num_of_refunds as usize - refunds_completed);
         }
 
-        assert!(Currencies::free_balance(CurrencyId::Native, &Proposals::project_account_id(0)) == 0u64)
+        assert_eq!(Currencies::free_balance(CurrencyId::Native, &Proposals::project_account_id(0)), 0u64);
     });
 } 
 

--- a/pallets/proposals/src/tests.rs
+++ b/pallets/proposals/src/tests.rs
@@ -2248,8 +2248,7 @@ fn test_finalise_vote_of_no_confidence_refunds_contributors() {
         // Wait blocks so that refunds occur;
         run_to_block(System::block_number() + 2);
         // assert that the voters have had their funds refunded.
-        let contribution_after_fee_charlie = (750_000u64 * (100 - <Test as Config>::PercentFeeOnApproval::get() as u64)) / 100;
-        dbg!(&RefundQueue::<Test>::get());
+        let contribution_after_fee_charlie = 750_000u64 * (100 - <Test as Config>::PercentFeeOnApproval::get() as u64) / 100;
         let contribution_after_fee_bob = 250_000u64 * (100 - <Test as Config>::PercentFeeOnApproval::get() as u64) / 100;
         assert_eq!(Currencies::free_balance(CurrencyId::Native, &charlie), contribution_after_fee_charlie + 250_000);
         assert_eq!(Currencies::free_balance(CurrencyId::Native, &bob), contribution_after_fee_bob + 750_000);

--- a/pallets/proposals/src/tests.rs
+++ b/pallets/proposals/src/tests.rs
@@ -2244,11 +2244,15 @@ fn test_finalise_vote_of_no_confidence_refunds_contributors() {
             project_key
         ));
 
-        // Wait a block so that refunds occur;
-        run_to_block(System::block_number() + 1);
+        let project_in_q = Projects::<Test>::get(project_key).unwrap();
+        // Wait blocks so that refunds occur;
+        run_to_block(System::block_number() + 2);
         // assert that the voters have had their funds refunded.
-        assert!(Currencies::free_balance(CurrencyId::Native, &charlie) == 1_000_000u64);
-        assert!(Currencies::free_balance(CurrencyId::Native, &bob) == 1_000_000u64);
+        let contribution_after_fee_charlie = (750_000u64 * (100 - <Test as Config>::PercentFeeOnApproval::get() as u64)) / 100;
+        dbg!(&RefundQueue::<Test>::get());
+        let contribution_after_fee_bob = 250_000u64 * (100 - <Test as Config>::PercentFeeOnApproval::get() as u64) / 100;
+        assert_eq!(Currencies::free_balance(CurrencyId::Native, &charlie), contribution_after_fee_charlie + 250_000);
+        assert_eq!(Currencies::free_balance(CurrencyId::Native, &bob), contribution_after_fee_bob + 750_000);
     });
 
 }

--- a/pallets/proposals/src/tests.rs
+++ b/pallets/proposals/src/tests.rs
@@ -5,7 +5,7 @@ use crate::*;
 use common_types::CurrencyId;
 use frame_support::{
     assert_noop, assert_ok, bounded_btree_map, bounded_vec, dispatch::DispatchErrorWithPostInfo,
-    weights::PostDispatchInfo, log::info
+    weights::PostDispatchInfo
 };
 use sp_core::sr25519;
 use sp_std::vec::Vec;
@@ -1754,7 +1754,6 @@ fn create_a_test_project_and_schedule_round_and_contribute_and_refund() {
 }
 
 // What exactly does this mean xd.
-// 
 #[test]
 fn withdraw_percentage_milestone_completed_refund_locked_milestone() {
     let alice = get_account_id_from_seed::<sr25519::Public>("Alice");
@@ -2386,7 +2385,7 @@ fn test_treasury_recieves_exact_fee() {
             System::block_number() + 100,
             bounded_vec![0u32],
             RoundType::ContributionRound
-        ).unwrap();
+        ).unwrap(); 
         
         let _ = Currencies::deposit(CurrencyId::Native, &bob, 2_000_000u64);
         let _ = Proposals::contribute(Origin::signed(bob), Some(1), project_key, 1_000_000).unwrap();

--- a/runtime/imbue-kusama/src/lib.rs
+++ b/runtime/imbue-kusama/src/lib.rs
@@ -779,7 +779,8 @@ parameter_types! {
 
     // Maximum number of approvals that can be in the spending queue
     pub const MaxApprovals: u32 = 100;
-}
+
+    }
 
 impl pallet_treasury::Config for Runtime {
     type Currency = Balances;
@@ -803,6 +804,10 @@ impl pallet_treasury::Config for Runtime {
     type SpendFunds = ();
     type MaxApprovals = MaxApprovals;
 }
+parameter_types! {
+    // Percent fee taken when a project is approved
+    pub const PercentFeeOnApproval: u8 = 3;
+}
 
 impl proposals::Config for Runtime {
     type Event = Event;
@@ -814,6 +819,9 @@ impl proposals::Config for Runtime {
     type NoConfidenceTimeLimit = NoConfidenceTimeLimit;
     type PercentRequiredForVoteToPass = PercentRequiredForVoteToPass;
     type WeightInfo = ();
+    type TreasuryId = TreasuryAccount;
+    type PercentFeeOnApproval = PercentFeeOnApproval;
+
 }
 
 construct_runtime! {


### PR DESCRIPTION
This completes the [Take fee on approval task](https://app.clickup.com/t/3rcdkhj).

The system will take a fee per milestone approval. 
For example if the raised funds is 100_000, the milestone is 50%, and the fee is 1% then the calculation is:
``` 100_000 * 0.5 * 0.01```

Refunds should be untouched as they only apply to unapproved milestones (therefore a fee has not been taken).

Possible issues that need review: 
- We are not using an up to date chainstate which means that the treasury account id is not funded when benchmarks are run.
- This means that small amounts of raised funds error because the existential deposit is greater than the funds transferred to the empty treasury account. Ensuring that the treasury account is funded will make this a non issue, perhaps we can add this for benchmarking.
- Due to the rounding down of calculations, we may be left with some dust and at the moment we dont handle it at all, I am thinking some kind of OnUnbalanced trait to deal with this where appropriate.

TLDR issues: 
- Use up to date chainstate.
- handle dust after calculations.

If everyones ok i will add these to clickup.

Todo: Migration for project  - [ ] 