### PR TITLE
Change finalise milestone vote to use common threshold

### DIFF
--- a/pallets/proposals/src/impls.rs
+++ b/pallets/proposals/src/impls.rs
@@ -305,9 +305,11 @@ impl<T: Config> Pallet<T> {
         );
 
         let end = now + MilestoneVotingWindow::<T>::get().into();
+        
         let round_key = RoundCount::<T>::get()
             .checked_add(1)
             .ok_or(Error::<T>::Overflow)?;
+
         let round = RoundOf::<T>::new(now, end, vec![project_key], RoundType::VotingRound);
 
         let vote = Vote::default();
@@ -399,7 +401,6 @@ impl<T: Config> Pallet<T> {
             Error::<T>::OnlyInitiatorOrAdminCanApproveMilestone
         );
 
-        let total_contribution_amount: BalanceOf<T> = project.raised_funds;
         ensure!(
             project.milestones.contains_key(&milestone_key),
             Error::<T>::MilestoneDoesNotExist
@@ -410,9 +411,11 @@ impl<T: Config> Pallet<T> {
         // set is_approved
         let vote_lookup_key = (project_key, milestone_key);
         let vote = Self::milestone_votes(vote_lookup_key).ok_or(Error::<T>::KeyNotFound)?;
-        let total_votes = vote.yay + vote.nay;
+
+        // let the 100 x threshold required = total_votes * majority required
+        let threshold_votes: BalanceOf<T> = project.raised_funds * T::PercentRequiredForVoteToPass::get().into();
         ensure!(
-            total_votes == total_contribution_amount,
+             (vote.yay + vote.nay) >= threshold_votes,
             Error::<T>::MilestoneVotingNotComplete
         );
         if vote.yay > vote.nay {

--- a/pallets/proposals/src/impls.rs
+++ b/pallets/proposals/src/impls.rs
@@ -414,8 +414,9 @@ impl<T: Config> Pallet<T> {
 
         // let the 100 x threshold required = total_votes * majority required
         let threshold_votes: BalanceOf<T> = project.raised_funds * T::PercentRequiredForVoteToPass::get().into();
+        let percent_multiple : BalanceOf<T> = 100u32.into();
         ensure!(
-             (vote.yay + vote.nay) >= threshold_votes,
+             (percent_multiple * (vote.yay + vote.nay)) >= threshold_votes,
             Error::<T>::MilestoneVotingNotComplete
         );
         if vote.yay > vote.nay {

--- a/pallets/proposals/src/lib.rs
+++ b/pallets/proposals/src/lib.rs
@@ -606,6 +606,7 @@ pub mod pallet {
             project_key: ProjectKey,
             milestone_key: MilestoneKey,
         ) -> DispatchResultWithPostInfo {
+            // Must be the initiator.
             let who = ensure_signed(origin)?;
             Self::do_finalise_milestone_voting(who, project_key, milestone_key)
         }


### PR DESCRIPTION
The finalise no vote now uses the threshold percentage as defined in the config.
A test has been written to assert that it does function when the threshold has been exactly reached.
