### PR TITLE
Proposals RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c
 dependencies = [
  "beefy-gadget",
  "futures 0.3.28",
- "jsonrpsee 0.16.2",
+ "jsonrpsee",
  "log",
  "parity-scale-codec 3.6.2",
  "parking_lot 0.12.1",
@@ -2026,7 +2026,7 @@ dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "futures 0.3.28",
- "jsonrpsee-core 0.16.2",
+ "jsonrpsee-core",
  "parity-scale-codec 3.6.2",
  "polkadot-overseer",
  "polkadot-service",
@@ -2088,7 +2088,7 @@ dependencies = [
  "cumulus-relay-chain-interface",
  "futures 0.3.28",
  "futures-timer",
- "jsonrpsee 0.16.2",
+ "jsonrpsee",
  "lru 0.9.0",
  "parity-scale-codec 3.6.2",
  "polkadot-service",
@@ -3870,7 +3870,7 @@ dependencies = [
  "futures 0.3.28",
  "hex-literal",
  "imbue-kusama-runtime",
- "jsonrpsee 0.16.2",
+ "jsonrpsee",
  "log",
  "nix 0.17.0",
  "pallet-collective",
@@ -4205,28 +4205,14 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd0d559d5e679b1ab2f869b486a11182923863b1b3ee8b421763cdd707b783a"
-dependencies = [
- "jsonrpsee-core 0.15.1",
- "jsonrpsee-http-server",
- "jsonrpsee-proc-macros 0.15.1",
- "jsonrpsee-types 0.15.1",
- "jsonrpsee-ws-server",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d291e3a5818a2384645fd9756362e6d89cf0541b0b916fa7702ea4a9833608e"
 dependencies = [
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-proc-macros 0.16.2",
+ "jsonrpsee-core",
+ "jsonrpsee-proc-macros",
  "jsonrpsee-server",
- "jsonrpsee-types 0.16.2",
+ "jsonrpsee-types",
  "jsonrpsee-ws-client",
  "tracing",
 ]
@@ -4239,8 +4225,8 @@ checksum = "965de52763f2004bc91ac5bcec504192440f0b568a5d621c59d9dbd6f886c3fb"
 dependencies = [
  "futures-util",
  "http",
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-types 0.16.2",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "pin-project",
  "rustls-native-certs",
  "soketto",
@@ -4250,35 +4236,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "webpki-roots",
-]
-
-[[package]]
-name = "jsonrpsee-core"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3dc3e9cf2ba50b7b1d7d76a667619f82846caa39e8e8daa8a4962d74acaddca"
-dependencies = [
- "anyhow",
- "arrayvec 0.7.4",
- "async-trait",
- "beef",
- "futures-channel",
- "futures-util",
- "globset",
- "http",
- "hyper",
- "jsonrpsee-types 0.15.1",
- "lazy_static",
- "parking_lot 0.12.1",
- "rand 0.8.5",
- "rustc-hash",
- "serde",
- "serde_json",
- "soketto",
- "thiserror",
- "tokio",
- "tracing",
- "unicase",
 ]
 
 [[package]]
@@ -4297,7 +4254,7 @@ dependencies = [
  "futures-util",
  "globset",
  "hyper",
- "jsonrpsee-types 0.16.2",
+ "jsonrpsee-types",
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "rustc-hash",
@@ -4307,36 +4264,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-http-server"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03802f0373a38c2420c70b5144742d800b509e2937edc4afb116434f07120117"
-dependencies = [
- "futures-channel",
- "futures-util",
- "hyper",
- "jsonrpsee-core 0.15.1",
- "jsonrpsee-types 0.15.1",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "jsonrpsee-proc-macros"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd67957d4280217247588ac86614ead007b301ca2fa9f19c19f880a536f029e3"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4362,8 +4289,8 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-types 0.16.2",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "serde",
  "serde_json",
  "soketto",
@@ -4371,20 +4298,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tower",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e290bba767401b646812f608c099b922d8142603c9e73a50fb192d3ac86f4a0d"
-dependencies = [
- "anyhow",
- "beef",
- "serde",
- "serde_json",
- "thiserror",
  "tracing",
 ]
 
@@ -4410,28 +4323,8 @@ checksum = "0b83daeecfc6517cfe210df24e570fb06213533dfb990318fae781f4c7119dd9"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-types 0.16.2",
-]
-
-[[package]]
-name = "jsonrpsee-ws-server"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d488ba74fb369e5ab68926feb75a483458b88e768d44319f37e4ecad283c7325"
-dependencies = [
- "futures-channel",
- "futures-util",
- "http",
- "jsonrpsee-core 0.15.1",
- "jsonrpsee-types 0.15.1",
- "serde_json",
- "soketto",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
- "tracing-futures",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
 ]
 
 [[package]]
@@ -5514,7 +5407,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "anyhow",
- "jsonrpsee 0.16.2",
+ "jsonrpsee",
  "parity-scale-codec 3.6.2",
  "serde",
  "sp-api",
@@ -6972,7 +6865,7 @@ dependencies = [
 name = "pallet-proposals-rpc"
 version = "0.1.0"
 dependencies = [
- "jsonrpsee 0.15.1",
+ "jsonrpsee",
  "pallet-proposals-rpc-runtime-api",
  "parity-scale-codec 3.6.2",
  "sp-api",
@@ -7265,7 +7158,7 @@ name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
- "jsonrpsee 0.16.2",
+ "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec 3.6.2",
  "sp-api",
@@ -8580,7 +8473,7 @@ source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.39#c22e
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
- "jsonrpsee 0.16.2",
+ "jsonrpsee",
  "mmr-rpc",
  "pallet-transaction-payment-rpc",
  "polkadot-primitives",
@@ -10386,7 +10279,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "futures 0.3.28",
- "jsonrpsee 0.16.2",
+ "jsonrpsee",
  "sc-consensus-babe",
  "sc-consensus-epochs",
  "sc-rpc-api",
@@ -10553,7 +10446,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c
 dependencies = [
  "finality-grandpa",
  "futures 0.3.28",
- "jsonrpsee 0.16.2",
+ "jsonrpsee",
  "log",
  "parity-scale-codec 3.6.2",
  "sc-client-api",
@@ -10832,7 +10725,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "futures 0.3.28",
- "jsonrpsee 0.16.2",
+ "jsonrpsee",
  "log",
  "parity-scale-codec 3.6.2",
  "parking_lot 0.12.1",
@@ -10861,7 +10754,7 @@ name = "sc-rpc-api"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
- "jsonrpsee 0.16.2",
+ "jsonrpsee",
  "parity-scale-codec 3.6.2",
  "sc-chain-spec",
  "sc-transaction-pool-api",
@@ -10881,7 +10774,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "http",
- "jsonrpsee 0.16.2",
+ "jsonrpsee",
  "log",
  "serde_json",
  "substrate-prometheus-endpoint",
@@ -10899,7 +10792,7 @@ dependencies = [
  "futures 0.3.28",
  "futures-util",
  "hex",
- "jsonrpsee 0.16.2",
+ "jsonrpsee",
  "log",
  "parity-scale-codec 3.6.2",
  "parking_lot 0.12.1",
@@ -10926,7 +10819,7 @@ dependencies = [
  "exit-future 0.2.0",
  "futures 0.3.28",
  "futures-timer",
- "jsonrpsee 0.16.2",
+ "jsonrpsee",
  "log",
  "parity-scale-codec 3.6.2",
  "parking_lot 0.12.1",
@@ -11014,7 +10907,7 @@ name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
- "jsonrpsee 0.16.2",
+ "jsonrpsee",
  "parity-scale-codec 3.6.2",
  "sc-chain-spec",
  "sc-client-api",
@@ -12586,7 +12479,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.28",
- "jsonrpsee 0.16.2",
+ "jsonrpsee",
  "log",
  "parity-scale-codec 3.6.2",
  "sc-rpc-api",
@@ -12616,7 +12509,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "async-trait",
- "jsonrpsee 0.16.2",
+ "jsonrpsee",
  "log",
  "sc-rpc-api",
  "serde",
@@ -12628,7 +12521,7 @@ name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
- "jsonrpsee 0.16.2",
+ "jsonrpsee",
  "log",
  "parity-scale-codec 3.6.2",
  "sc-client-api",
@@ -13371,15 +13264,6 @@ dependencies = [
  "crunchy",
  "hex",
  "static_assertions",
-]
-
-[[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c
 dependencies = [
  "beefy-gadget",
  "futures 0.3.28",
- "jsonrpsee",
+ "jsonrpsee 0.16.2",
  "log",
  "parity-scale-codec 3.6.2",
  "parking_lot 0.12.1",
@@ -2026,7 +2026,7 @@ dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "futures 0.3.28",
- "jsonrpsee-core",
+ "jsonrpsee-core 0.16.2",
  "parity-scale-codec 3.6.2",
  "polkadot-overseer",
  "polkadot-service",
@@ -2088,7 +2088,7 @@ dependencies = [
  "cumulus-relay-chain-interface",
  "futures 0.3.28",
  "futures-timer",
- "jsonrpsee",
+ "jsonrpsee 0.16.2",
  "lru 0.9.0",
  "parity-scale-codec 3.6.2",
  "polkadot-service",
@@ -3870,10 +3870,11 @@ dependencies = [
  "futures 0.3.28",
  "hex-literal",
  "imbue-kusama-runtime",
- "jsonrpsee",
+ "jsonrpsee 0.16.2",
  "log",
  "nix 0.17.0",
  "pallet-collective",
+ "pallet-proposals-rpc",
  "pallet-transaction-payment-rpc",
  "pallet-xcm",
  "parachains-common",
@@ -3976,6 +3977,7 @@ dependencies = [
  "pallet-multisig",
  "pallet-preimage",
  "pallet-proposals",
+ "pallet-proposals-rpc-runtime-api",
  "pallet-scheduler",
  "pallet-session",
  "pallet-sudo",
@@ -4203,14 +4205,28 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bd0d559d5e679b1ab2f869b486a11182923863b1b3ee8b421763cdd707b783a"
+dependencies = [
+ "jsonrpsee-core 0.15.1",
+ "jsonrpsee-http-server",
+ "jsonrpsee-proc-macros 0.15.1",
+ "jsonrpsee-types 0.15.1",
+ "jsonrpsee-ws-server",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d291e3a5818a2384645fd9756362e6d89cf0541b0b916fa7702ea4a9833608e"
 dependencies = [
- "jsonrpsee-core",
- "jsonrpsee-proc-macros",
+ "jsonrpsee-core 0.16.2",
+ "jsonrpsee-proc-macros 0.16.2",
  "jsonrpsee-server",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.16.2",
  "jsonrpsee-ws-client",
  "tracing",
 ]
@@ -4223,8 +4239,8 @@ checksum = "965de52763f2004bc91ac5bcec504192440f0b568a5d621c59d9dbd6f886c3fb"
 dependencies = [
  "futures-util",
  "http",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.16.2",
+ "jsonrpsee-types 0.16.2",
  "pin-project",
  "rustls-native-certs",
  "soketto",
@@ -4234,6 +4250,35 @@ dependencies = [
  "tokio-util",
  "tracing",
  "webpki-roots",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3dc3e9cf2ba50b7b1d7d76a667619f82846caa39e8e8daa8a4962d74acaddca"
+dependencies = [
+ "anyhow",
+ "arrayvec 0.7.4",
+ "async-trait",
+ "beef",
+ "futures-channel",
+ "futures-util",
+ "globset",
+ "http",
+ "hyper",
+ "jsonrpsee-types 0.15.1",
+ "lazy_static",
+ "parking_lot 0.12.1",
+ "rand 0.8.5",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "unicase",
 ]
 
 [[package]]
@@ -4252,7 +4297,7 @@ dependencies = [
  "futures-util",
  "globset",
  "hyper",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.16.2",
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "rustc-hash",
@@ -4262,6 +4307,36 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-http-server"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03802f0373a38c2420c70b5144742d800b509e2937edc4afb116434f07120117"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "hyper",
+ "jsonrpsee-core 0.15.1",
+ "jsonrpsee-types 0.15.1",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "jsonrpsee-proc-macros"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd67957d4280217247588ac86614ead007b301ca2fa9f19c19f880a536f029e3"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4287,8 +4362,8 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.16.2",
+ "jsonrpsee-types 0.16.2",
  "serde",
  "serde_json",
  "soketto",
@@ -4296,6 +4371,20 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tower",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e290bba767401b646812f608c099b922d8142603c9e73a50fb192d3ac86f4a0d"
+dependencies = [
+ "anyhow",
+ "beef",
+ "serde",
+ "serde_json",
+ "thiserror",
  "tracing",
 ]
 
@@ -4321,8 +4410,28 @@ checksum = "0b83daeecfc6517cfe210df24e570fb06213533dfb990318fae781f4c7119dd9"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.16.2",
+ "jsonrpsee-types 0.16.2",
+]
+
+[[package]]
+name = "jsonrpsee-ws-server"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d488ba74fb369e5ab68926feb75a483458b88e768d44319f37e4ecad283c7325"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "http",
+ "jsonrpsee-core 0.15.1",
+ "jsonrpsee-types 0.15.1",
+ "serde_json",
+ "soketto",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -5405,7 +5514,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "anyhow",
- "jsonrpsee",
+ "jsonrpsee 0.16.2",
  "parity-scale-codec 3.6.2",
  "serde",
  "sp-api",
@@ -6860,6 +6969,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-proposals-rpc"
+version = "0.1.0"
+dependencies = [
+ "jsonrpsee 0.15.1",
+ "pallet-proposals-rpc-runtime-api",
+ "parity-scale-codec 3.6.2",
+ "sp-api",
+ "sp-blockchain",
+ "sp-rpc",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-proposals-rpc-runtime-api"
+version = "0.1.0"
+dependencies = [
+ "parity-scale-codec 3.6.2",
+ "sp-api",
+]
+
+[[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
@@ -7135,7 +7265,7 @@ name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.16.2",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec 3.6.2",
  "sp-api",
@@ -8450,7 +8580,7 @@ source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.39#c22e
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
- "jsonrpsee",
+ "jsonrpsee 0.16.2",
  "mmr-rpc",
  "pallet-transaction-payment-rpc",
  "polkadot-primitives",
@@ -10256,7 +10386,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "futures 0.3.28",
- "jsonrpsee",
+ "jsonrpsee 0.16.2",
  "sc-consensus-babe",
  "sc-consensus-epochs",
  "sc-rpc-api",
@@ -10423,7 +10553,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c
 dependencies = [
  "finality-grandpa",
  "futures 0.3.28",
- "jsonrpsee",
+ "jsonrpsee 0.16.2",
  "log",
  "parity-scale-codec 3.6.2",
  "sc-client-api",
@@ -10702,7 +10832,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "futures 0.3.28",
- "jsonrpsee",
+ "jsonrpsee 0.16.2",
  "log",
  "parity-scale-codec 3.6.2",
  "parking_lot 0.12.1",
@@ -10731,7 +10861,7 @@ name = "sc-rpc-api"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.16.2",
  "parity-scale-codec 3.6.2",
  "sc-chain-spec",
  "sc-transaction-pool-api",
@@ -10751,7 +10881,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "http",
- "jsonrpsee",
+ "jsonrpsee 0.16.2",
  "log",
  "serde_json",
  "substrate-prometheus-endpoint",
@@ -10769,7 +10899,7 @@ dependencies = [
  "futures 0.3.28",
  "futures-util",
  "hex",
- "jsonrpsee",
+ "jsonrpsee 0.16.2",
  "log",
  "parity-scale-codec 3.6.2",
  "parking_lot 0.12.1",
@@ -10796,7 +10926,7 @@ dependencies = [
  "exit-future 0.2.0",
  "futures 0.3.28",
  "futures-timer",
- "jsonrpsee",
+ "jsonrpsee 0.16.2",
  "log",
  "parity-scale-codec 3.6.2",
  "parking_lot 0.12.1",
@@ -10884,7 +11014,7 @@ name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.16.2",
  "parity-scale-codec 3.6.2",
  "sc-chain-spec",
  "sc-client-api",
@@ -12456,7 +12586,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.28",
- "jsonrpsee",
+ "jsonrpsee 0.16.2",
  "log",
  "parity-scale-codec 3.6.2",
  "sc-rpc-api",
@@ -12486,7 +12616,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "async-trait",
- "jsonrpsee",
+ "jsonrpsee 0.16.2",
  "log",
  "sc-rpc-api",
  "serde",
@@ -12498,7 +12628,7 @@ name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.16.2",
  "log",
  "parity-scale-codec 3.6.2",
  "sc-client-api",
@@ -13241,6 +13371,15 @@ dependencies = [
  "crunchy",
  "hex",
  "static_assertions",
+]
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -111,6 +111,9 @@ polkadot-cli = { git = "https://github.com/paritytech/polkadot", branch = "relea
 polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.39" }
 xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.39", default-features = false }
 
+#local dependancies
+pallet-proposals-rpc = {path = "../pallets/proposals/rpc" }
+
 [build-dependencies]
 substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.39" }
 

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -42,11 +42,12 @@ where
     C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
     C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
     C::Api: BlockBuilder<Block>,
+    C::Api: pallet_proposals_rpc::ProposalsRuntimeApi<AccountId>,
     P: TransactionPool + Sync + Send + 'static,
 {
     use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
     use substrate_frame_rpc_system::{System, SystemApiServer};
-    
+    use pallet_proposals_rpc::{Proposals, ProposalsApiServer};
 
     let mut module = RpcExtension::new(());
     let FullDeps {
@@ -57,5 +58,6 @@ where
 
     module.merge(System::new(client.clone(), pool, deny_unsafe).into_rpc())?;
     module.merge(TransactionPayment::new(client).into_rpc())?;
+    module.merge(Proposals::new(client).into_rpc())?;
     Ok(module)
 }

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -46,6 +46,7 @@ where
 {
     use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
     use substrate_frame_rpc_system::{System, SystemApiServer};
+    
 
     let mut module = RpcExtension::new(());
     let FullDeps {

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -42,7 +42,7 @@ where
     C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
     C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
     C::Api: BlockBuilder<Block>,
-    C::Api: pallet_proposals_rpc::ProposalsRuntimeApi<AccountId>,
+    C::Api: pallet_proposals_rpc::ProposalsRuntimeApi<Block, AccountId>,
     P: TransactionPool + Sync + Send + 'static,
 {
     use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
@@ -57,7 +57,7 @@ where
     } = deps;
 
     module.merge(System::new(client.clone(), pool, deny_unsafe).into_rpc())?;
-    module.merge(TransactionPayment::new(client).into_rpc())?;
-    module.merge(Proposals::new(client).into_rpc())?;
+    module.merge(TransactionPayment::new(client.clone()).into_rpc())?;
+    module.merge(Proposals::new(client.clone()).into_rpc())?;
     Ok(module)
 }

--- a/pallets/proposals/rpc/Cargo.toml
+++ b/pallets/proposals/rpc/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rpc"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/pallets/proposals/rpc/Cargo.toml
+++ b/pallets/proposals/rpc/Cargo.toml
@@ -13,11 +13,10 @@ jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
 
 # Substrate packages
 sp-api = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }
+sp-rpc = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }
 sp-blockchain = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }
-sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }
-frame_system = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }
-
-pallet-proposals-rpc-runtime-api = { version = "4.0.0-dev", path = "./runtime-api" }
+sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }
+pallet-proposals-rpc-runtime-api = {path = "./runtime-api" }
 
 
 [features]
@@ -25,6 +24,4 @@ default = ["std"]
 std = [
   "sp-api/std",
   "sp-runtime/std",
-  "frame_system/std",
-  "pallet-proposals-rpc-runtime-api/std"
 ]

--- a/pallets/proposals/rpc/Cargo.toml
+++ b/pallets/proposals/rpc/Cargo.toml
@@ -4,12 +4,27 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1" }
-jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"] }
-pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", path = "./runtime-api" }
-sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
-sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
-sp-core = { version = "21.0.0", path = "../../../primitives/core" }
-sp-rpc = { version = "6.0.0", path = "../../../primitives/rpc" }
-sp-runtime = { version = "24.0.0", path = "../../../primitives/runtime" }
-sp-weights = { version = "20.0.0", path = "../../../primitives/weights" }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+	"derive",
+] }
+
+jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
+
+
+# Substrate packages
+sp-api = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }
+sp-blockchain = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }
+sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }
+frame_system = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }
+
+pallet-proposals-rpc-runtime-api = { version = "4.0.0-dev", path = "./runtime-api" }
+
+
+[features]
+default = ["std"]
+std = [
+  "sp-api/std",
+  "sp-runtime/std",
+  "frame_system/std",
+  "pallet-proposals-rpc-runtime-api/std"
+]

--- a/pallets/proposals/rpc/Cargo.toml
+++ b/pallets/proposals/rpc/Cargo.toml
@@ -8,7 +8,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 	"derive",
 ] }
 
-jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
+jsonrpsee = { version = "0.16.2", features = ["server", "macros"] }
 
 
 # Substrate packages

--- a/pallets/proposals/rpc/Cargo.toml
+++ b/pallets/proposals/rpc/Cargo.toml
@@ -1,8 +1,15 @@
 [package]
-name = "rpc"
+name = "pallet-proposals-rpc"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+codec = { package = "parity-scale-codec", version = "3.6.1" }
+jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"] }
+pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", path = "./runtime-api" }
+sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
+sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
+sp-core = { version = "21.0.0", path = "../../../primitives/core" }
+sp-rpc = { version = "6.0.0", path = "../../../primitives/rpc" }
+sp-runtime = { version = "24.0.0", path = "../../../primitives/runtime" }
+sp-weights = { version = "20.0.0", path = "../../../primitives/weights" }

--- a/pallets/proposals/rpc/runtime-api/Cargo.toml
+++ b/pallets/proposals/rpc/runtime-api/Cargo.toml
@@ -3,7 +3,8 @@ name = "pallet-proposals-rpc-runtime-api"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
@@ -11,3 +12,9 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 ] }
 
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39"}
+
+[features]
+default = ["std"]
+std = [
+    "sp-api/std",
+]

--- a/pallets/proposals/rpc/runtime-api/Cargo.toml
+++ b/pallets/proposals/rpc/runtime-api/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "runtime-api"
+name = "pallet-proposals-rpc-runtime-api"
 version = "0.1.0"
 edition = "2021"
 

--- a/pallets/proposals/rpc/runtime-api/Cargo.toml
+++ b/pallets/proposals/rpc/runtime-api/Cargo.toml
@@ -6,5 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sp-api = { version = "4.0.0-dev", default-features = false, path = "../../../../primitives/api" }
-pallet-proposals = {default-features = false, path = "../../../proposals" }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+	"derive",
+] }
+
+sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39"}

--- a/pallets/proposals/rpc/runtime-api/Cargo.toml
+++ b/pallets/proposals/rpc/runtime-api/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "runtime-api"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+sp-api = { version = "4.0.0-dev", default-features = false, path = "../../../../primitives/api" }
+pallet-proposals = {default-features = false, path = "../../../proposals" }

--- a/pallets/proposals/rpc/runtime-api/src/lib.rs
+++ b/pallets/proposals/rpc/runtime-api/src/lib.rs
@@ -1,4 +1,5 @@
 sp_api::decl_runtime_apis! {
+    #[api_version(1)]
     pub trait ProjectsApi<AccountId> where AccountId: codec::Codec {
         fn get_project_account_by_id(project_id: u32) -> AccountId;
     }

--- a/pallets/proposals/rpc/runtime-api/src/lib.rs
+++ b/pallets/proposals/rpc/runtime-api/src/lib.rs
@@ -1,5 +1,6 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 sp_api::decl_runtime_apis! {
-    #[api_version(1)]
     pub trait ProposalsApi<AccountId> where AccountId: codec::Codec {
         fn get_project_account_by_id(project_id: u32) -> AccountId;
     }

--- a/pallets/proposals/rpc/runtime-api/src/lib.rs
+++ b/pallets/proposals/rpc/runtime-api/src/lib.rs
@@ -1,6 +1,6 @@
 sp_api::decl_runtime_apis! {
     #[api_version(1)]
-    pub trait ProjectsApi<AccountId> where AccountId: codec::Codec {
+    pub trait ProposalsApi<AccountId> where AccountId: codec::Codec {
         fn get_project_account_by_id(project_id: u32) -> AccountId;
     }
 }

--- a/pallets/proposals/rpc/src/lib.rs
+++ b/pallets/proposals/rpc/src/lib.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/pallets/proposals/rpc/src/lib.rs
+++ b/pallets/proposals/rpc/src/lib.rs
@@ -1,3 +1,61 @@
-fn main() {
-    println!("Hello, world!");
+
+use codec::{Codec, Decode};
+use jsonrpsee::{
+	core::{Error as JsonRpseeError, RpcResult},
+	proc_macros::rpc,
+	types::error::{CallError, ErrorCode, ErrorObject},
+};
+use pallet_transaction_payment_rpc_runtime_api::{FeeDetails, InclusionFee, RuntimeDispatchInfo};
+use sp_api::ProvideRuntimeApi;
+use sp_blockchain::HeaderBackend;
+use sp_core::Bytes;
+use sp_rpc::number::NumberOrHex;
+use sp_runtime::traits::{Block as BlockT, MaybeDisplay};
+
+#[rpc(client, server)]
+pub trait ProposalsApi<AccountId> {
+	#[method(name = "getProjectKitty")]
+	fn get_project_account_by_id(project_id: u32) -> AccountId;
+}
+
+/// Provides RPC methods to query a dispatchable's class, weight and fee.
+pub struct Proposals<C, P> {
+	/// Shared reference to the client.
+	client: Arc<C>,
+	_marker: std::marker::PhantomData<P>,
+}
+
+impl<C, P> Proposals<C, P> {
+	pub fn new(client: Arc<C>) -> Self {
+		Self { client, _marker: Default::default() }
+	}
+}
+
+/// Error type of this RPC api.
+pub enum Error {
+	/// The transaction was not decodable.
+	DecodeError,
+	/// The call to runtime failed.
+	RuntimeError,
+}
+
+impl From<Error> for i32 {
+	fn from(e: Error) -> i32 {
+		match e {
+			Error::RuntimeError => 1,
+			Error::DecodeError => 2,
+		}
+	}
+}
+
+impl<C, AccountId>
+	ProposalsApiServer<
+		AccountId,
+	> for Proposals<C, Block>
+where
+	Block: BlockT,
+	C: ProvideRuntimeApi<Block> + HeaderBackend<Block> + Send + Sync + 'static,
+	C::Api: ProposalsRuntimeApi<AccountId>,
+{
+
 }

--- a/pallets/proposals/src/lib.rs
+++ b/pallets/proposals/src/lib.rs
@@ -19,9 +19,6 @@ use sp_std::{collections::btree_map::*, convert::TryInto, prelude::*};
 pub mod traits;
 use traits::{IntoProposal, RefundHandler};
 
-pub mod runtime_api;
-pub use runtime_api::*;
-
 #[cfg(test)]
 mod mock;
 

--- a/runtime/imbue-kusama/Cargo.toml
+++ b/runtime/imbue-kusama/Cargo.toml
@@ -105,7 +105,7 @@ pallet-grants = {path = '../../pallets/grants', default-features = false }
 pallet-deposits = {path = '../../pallets/deposits', default-features = false }
 common-traits = { path = "../../libs/common-traits", default-features = false }
 common-types = { path = "../../libs/common-types", default-features = false }
-pallet-proposals-runtime-api = {path = "../pallets/proposals/rpc/runtime-api", default-features = false}
+pallet-proposals-rpc-runtime-api = {path = "../../pallets/proposals/rpc/runtime-api", default-features = false}
 
 
 [dev-dependencies]
@@ -179,7 +179,6 @@ std = [
 	'pallet-proposals/std',
 	'pallet-briefs/std',
 	'pallet-grants/std',
-	'pallet-proposals-runtime-api/std',
 ]
 
 runtime-benchmarks = [

--- a/runtime/imbue-kusama/Cargo.toml
+++ b/runtime/imbue-kusama/Cargo.toml
@@ -105,6 +105,7 @@ pallet-grants = {path = '../../pallets/grants', default-features = false }
 pallet-deposits = {path = '../../pallets/deposits', default-features = false }
 common-traits = { path = "../../libs/common-traits", default-features = false }
 common-types = { path = "../../libs/common-types", default-features = false }
+pallet-proposals-runtime-api = {path = "../pallets/proposals/rpc/runtime-api", default-features = false}
 
 
 [dev-dependencies]
@@ -178,6 +179,7 @@ std = [
 	'pallet-proposals/std',
 	'pallet-briefs/std',
 	'pallet-grants/std',
+	'pallet-proposals-runtime-api/std',
 ]
 
 runtime-benchmarks = [

--- a/runtime/imbue-kusama/src/lib.rs
+++ b/runtime/imbue-kusama/src/lib.rs
@@ -1090,7 +1090,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl pallet_proposals::runtime_api::ProjectsApi<Block, AccountId> for Runtime {
+    impl pallet_proposals_rpc_runtime_api::ProposalsApi<Block, AccountId> for Runtime {
         fn get_project_account_by_id(project_id: u32) -> AccountId {
             ImbueProposals::project_account_id(project_id)
         }


### PR DESCRIPTION
Implemented the new rpc for proposals and included the get account id method.
To see it you need to go to polkadot js: RPC tab, call the methods function.

To see it normally in polkadot js we need a companion pr and add it to this repo: 
https://github.com/polkadot-js/apps/tree/master/packages/apps-config/src/api/spec
@cuteolaf Can you do this?