### PR TITLE
remove the round once the milestone has been approved

### DIFF
--- a/pallets/proposals/src/impls.rs
+++ b/pallets/proposals/src/impls.rs
@@ -114,8 +114,7 @@ impl<T: Config> Pallet<T> {
                 milestone_key,
                 <frame_system::Pallet<T>>::block_number(),
             ));
-            //TODO: Set vote as approved.
-            // set the vote as approved, set the milestone as approved.
+            Rounds::<T>::remove(project_key, RoundType::VotingRound);
         }
 
         Self::deposit_event(Event::VoteSubmitted(


### PR DESCRIPTION
The ui is showing the second milestone as open for voting

We should not store a round if a milestone has been approved, since there is no further reason to vote on it