### PR TITLE
Try and fix the ci error "out of space"

### DIFF
--- a/.github/workflows/collator_actions.yml
+++ b/.github/workflows/collator_actions.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Ensure executable
+        run: chmod +x ./ci/jobs/clean.sh
+
       - name: Clean env
         run: ./ci/jobs/clean.sh 
 

--- a/.github/workflows/collator_actions.yml
+++ b/.github/workflows/collator_actions.yml
@@ -32,12 +32,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Ensure executable
-        run: chmod +x ./ci/jobs/clean.sh
-
-      - name: Clean env
-        run: ./ci/jobs/clean.sh 
-
       - name: Install minimal nightly Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/collator_actions.yml
+++ b/.github/workflows/collator_actions.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Clean env
+        run: ./ci/jobs/clean.sh 
+
       - name: Install minimal nightly Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -47,8 +50,13 @@ jobs:
       runs-on: ubuntu-latest
       steps:
       - uses: actions/checkout@v4
+
+      - name: Clean unused directories
+        run: sudo rm -rf /usr/share/dotnet;sudo rm -rf /opt/ghc;sudo rm -rf "/usr/local/share/boost";sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
       - name: Install Protobuf
         run: sudo apt install protobuf-compiler
+
       - name: Install minimal nightly Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -56,19 +64,29 @@ jobs:
           toolchain: nightly-2023-05-22
           target: wasm32-unknown-unknown
           override: true
+      
       - name: Install clippy
         run: rustup component add clippy
+      
       - name: Ensure executable
         run: chmod +x ./ci/jobs/clippy.sh
+      
       - name: Run clippy
         run: ./ci/jobs/clippy.sh
+      
+      - name: clean build artifacts
+        run: sudo rm -rf ./target
+
   rustfmt:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+
     - name: Install rustfmt
       run: rustup component add rustfmt
+
     - name: Ensure executable
       run: chmod +x ./ci/jobs/rustfmt.sh
+
     - name: Run rustfmt
       run: ./ci/jobs/rustfmt.sh

--- a/.github/workflows/collator_actions.yml
+++ b/.github/workflows/collator_actions.yml
@@ -18,7 +18,15 @@ on:
 jobs:
   build-imbue-collator:
     runs-on: ubuntu-latest
+
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 512
+          swap-size-mb: 1024
+          remove-dotnet: 'true'
+          
       - name: Checkout sources
         uses: actions/checkout@v4
         with:

--- a/ci/jobs/clean.sh
+++ b/ci/jobs/clean.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")"
+echo "Cleaning swap and apt"
+
+sudo swapoff -a
+sudo rm -f /swapfile
+sudo apt clean


### PR DESCRIPTION
check the pr [for the runtime apis](https://github.com/ImbueNetwork/imbue/pull/224) and youll find the actions has failed due to lack of space. 
This pr attempts to fix that by: 
1. trying to remove the builds from `clippy`
2. running `apt clean` before running `cargo test` - removed
3. cleaning unused directories for `clippy`
4. Use a github action for removing unnecessary installations in the worker