### PR TITLE
upgrade cli args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /builds/imbue
 
 RUN cargo build --release
 
-FROM debian:buster-slim as collator
+FROM docker.io/library/ubuntu:20.04 as collator
 RUN apt-get update && apt-get install jq curl bash wget git curl bash make vim g++ -y && \
     curl -sSo /wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && \
     chmod +x /wait-for-it.sh && \

--- a/assets/docs/README_XCM.md
+++ b/assets/docs/README_XCM.md
@@ -99,7 +99,7 @@ This guide will show you step by step process to transfer the kusd from acala to
             "port": 31200,
             "name": "alice",
             "flags": [
-              "--unsafe-ws-external",
+              "--unsafe-rpc-external",
               "--unsafe-rpc-external",
               "--rpc-external",
               "--ws-external",
@@ -121,7 +121,7 @@ This guide will show you step by step process to transfer the kusd from acala to
             "port": 31300,
             "name": "alice",
             "flags": [
-              "--unsafe-ws-external",
+              "--unsafe-rpc-external",
               "--unsafe-rpc-external",
               "--rpc-external",
               "--ws-external",

--- a/scripts/docker-compose-kusama-archive.yml
+++ b/scripts/docker-compose-kusama-archive.yml
@@ -10,7 +10,7 @@ services:
       - "9980:9930"
       - "30333:30333"
       - "30334:30334"
-    command: bash -c "wget https://raw.githubusercontent.com/paritytech/polkadot/master/node/service/chain-specs/kusama.json;wget https://raw.githubusercontent.com/ImbueNetwork/imbue/main/res/genesis/imbue-kusama-spec.json;/imbue --collator --allow-private-ipv4 --unsafe-ws-external --rpc-cors=all --rpc-external --rpc-methods=Unsafe -d /cumulus_parachain/imbue-1 --name imbue-collator-1 --ws-port 9942 --rpc-port 9930 --parachain-id 2121 --chain imbue-kusama-spec.json --rpc-max-request-size=99999 --ws-max-connections=5000 --prometheus-external --port 30333 --pruning archive -- --port 30334 --chain kusama.json --sync warp"
+    command: bash -c "wget https://raw.githubusercontent.com/paritytech/polkadot/master/node/service/chain-specs/kusama.json;wget https://raw.githubusercontent.com/ImbueNetwork/imbue/main/res/genesis/imbue-kusama-spec.json;/imbue --collator --allow-private-ipv4 --unsafe-rpc-external --rpc-cors=all --rpc-external --rpc-methods=Unsafe -d /cumulus_parachain/imbue-1 --name imbue-collator-1 --rpc-port 9942  --parachain-id 2121 --chain imbue-kusama-spec.json --rpc-max-request-size=99999 --rpc-max-connections=5000 --prometheus-external --port 30333 --pruning archive -- --port 30334 --chain kusama.json --sync warp"
     volumes:
       - ./imbue_db/cumulus_parachain_1:/cumulus_parachain/
   frontend:

--- a/scripts/docker-compose-kusama.yml
+++ b/scripts/docker-compose-kusama.yml
@@ -13,7 +13,7 @@ services:
     environment:
       NODE_KEY: ${NODE_KEY}
       IP_ADDRESS: ${IP_ADDRESS}
-    command: bash -c "wget https://raw.githubusercontent.com/paritytech/polkadot/master/node/service/chain-specs/kusama.json;wget https://raw.githubusercontent.com/ImbueNetwork/imbue/main/res/genesis/imbue-kusama-spec.json;sed '/'"$IP_ADDRESS"'*/ d' imbue-kusama-spec.json >> fixed_spec; mv fixed_spec imbue-kusama-spec.json; /imbue --collator --allow-private-ipv4 --unsafe-ws-external --rpc-cors=all --rpc-external --rpc-methods=Unsafe -d /cumulus_parachain/imbue-1 --name imbue-collator-1 --node-key=$NODE_KEY --ws-port 9942 --rpc-port 9930 --parachain-id 2121 --chain imbue-kusama-spec.json --rpc-max-request-size=99999 --ws-max-connections=5000 --prometheus-external --port 30333 --pruning archive -- --port 30334 --chain kusama.json --sync warp"
+    command: bash -c "wget https://raw.githubusercontent.com/paritytech/polkadot/master/node/service/chain-specs/kusama.json;wget https://raw.githubusercontent.com/ImbueNetwork/imbue/main/res/genesis/imbue-kusama-spec.json;sed '/'"$IP_ADDRESS"'*/ d' imbue-kusama-spec.json >> fixed_spec; mv fixed_spec imbue-kusama-spec.json; /imbue --collator --allow-private-ipv4 --unsafe-rpc-external --rpc-cors=all --rpc-external --rpc-methods=Unsafe -d /cumulus_parachain/imbue-1 --name imbue-collator-1 --node-key=$NODE_KEY --rpc-port 9942  --parachain-id 2121 --chain imbue-kusama-spec.json --rpc-max-request-size=99999 --rpc-max-connections=5000 --prometheus-external --port 30333 --pruning archive -- --port 30334 --chain kusama.json --sync warp"
     volumes:
       - ./imbue_db/cumulus_parachain_1:/cumulus_parachain/
   frontend:

--- a/scripts/docker-compose-rococo-archive.yml
+++ b/scripts/docker-compose-rococo-archive.yml
@@ -10,7 +10,7 @@ services:
       - "9980:9930"
       - "30333:30333"
       - "30334:30334"
-    command: bash -c "wget https://raw.githubusercontent.com/paritytech/polkadot/master/node/service/chain-specs/rococo.json;wget https://raw.githubusercontent.com/ImbueNetwork/imbue/main/res/imbue-rococo-spec.json;/imbue --collator --allow-private-ipv4 --unsafe-ws-external --rpc-cors=all --rpc-external --rpc-methods=Unsafe -d /cumulus_parachain/imbue-1 --name imbue-collator-1 --ws-port 9942 --rpc-port 9930 --parachain-id 2121 --chain imbue-rococo-spec.json --rpc-max-request-size=99999 --ws-max-connections=5000 --prometheus-external --port 30333 --pruning archive -- --port 30334 --chain rococo.json --sync fast"
+    command: bash -c "wget https://raw.githubusercontent.com/paritytech/polkadot/master/node/service/chain-specs/rococo.json;wget https://raw.githubusercontent.com/ImbueNetwork/imbue/main/res/imbue-rococo-spec.json;/imbue --collator --allow-private-ipv4 --unsafe-rpc-external --rpc-cors=all --rpc-external --rpc-methods=Unsafe -d /cumulus_parachain/imbue-1 --name imbue-collator-1 --rpc-port 9942 --parachain-id 2121 --chain imbue-rococo-spec.json --rpc-max-request-size=99999 --rpc-max-connections=5000 --prometheus-external --port 30333 --pruning archive -- --port 30334 --chain rococo.json --sync fast"
     volumes:
       - ./imbue_db/cumulus_parachain_1:/cumulus_parachain/
   frontend:

--- a/scripts/docker-compose-rococo.yml
+++ b/scripts/docker-compose-rococo.yml
@@ -13,7 +13,7 @@ services:
     environment:
       NODE_KEY: ${NODE_KEY}
       IP_ADDRESS: ${IP_ADDRESS}
-    command: bash -c "wget https://raw.githubusercontent.com/paritytech/polkadot/master/node/service/chain-specs/rococo.json;wget https://raw.githubusercontent.com/ImbueNetwork/imbue/main/res/imbue-rococo-spec.json;sed '/'"$IP_ADDRESS"'*/ d' imbue-rococo-spec.json >> fixed_spec; mv fixed_spec imbue-rococo-spec.json; /imbue --collator --allow-private-ipv4 --unsafe-ws-external --rpc-cors=all --rpc-external --rpc-methods=Unsafe -d /cumulus_parachain/imbue-1 --name imbue-collator-1 --node-key=$NODE_KEY --ws-port 9942 --rpc-port 9930 --parachain-id 2121 --chain imbue-rococo-spec.json --rpc-max-request-size=99999 --ws-max-connections=5000 --prometheus-external --port 30333 --sync fast -- --port 30334 --chain rococo.json --sync fast"
+    command: bash -c "wget https://raw.githubusercontent.com/paritytech/polkadot/master/node/service/chain-specs/rococo.json;wget https://raw.githubusercontent.com/ImbueNetwork/imbue/main/res/imbue-rococo-spec.json;sed '/'"$IP_ADDRESS"'*/ d' imbue-rococo-spec.json >> fixed_spec; mv fixed_spec imbue-rococo-spec.json; /imbue --collator --allow-private-ipv4 --unsafe-rpc-external --rpc-cors=all --rpc-external --rpc-methods=Unsafe -d /cumulus_parachain/imbue-1 --name imbue-collator-1 --node-key=$NODE_KEY --rpc-port 9942  --parachain-id 2121 --chain imbue-rococo-spec.json --rpc-max-request-size=99999 --rpc-max-connections=5000 --prometheus-external --port 30333 --sync fast -- --port 30334 --chain rococo.json --sync fast"
     volumes:
       - ./imbue_db/cumulus_parachain_1:/cumulus_parachain/
   frontend:

--- a/scripts/docker-compose-separate-services.yml
+++ b/scripts/docker-compose-separate-services.yml
@@ -7,7 +7,7 @@ services:
       - "9912:9934"
       - "9914:9944"
       - "30301:30331"
-    command: bash -c "/polkadot --unsafe-ws-external --allow-private-ipv4 --rpc-cors all  --log=parity_ws::io=debug --wasm-execution Compiled --rpc-external --rpc-methods Unsafe -d /cumulus_relay/alice --validator --alice --ws-port 9944 --port 30331 --rpc-port 9934 --name alice --chain rococo-local.json --ws-max-connections=200"
+    command: bash -c "/polkadot --unsafe-rpc-external --allow-private-ipv4 --rpc-cors all  --log=parity_ws::io=debug --wasm-execution Compiled --rpc-external --rpc-methods Unsafe -d /cumulus_relay/alice --validator --alice --rpc-port 9944 --port 30331 --rpc-port 9934 --name alice --chain rococo-local.json --rpc-max-connections=200"
     volumes:
       - ./imbue_db/cumulus_relay:/cumulus_relay/
 
@@ -18,7 +18,7 @@ services:
       - "9915:9934"
       - "9916:9944"
       - "30302:30331"
-    command: bash -c "/polkadot --unsafe-ws-external --allow-private-ipv4 --rpc-cors all --wasm-execution Compiled --rpc-external --rpc-methods Unsafe -d /cumulus_relay/bob --validator --bob --ws-port 9944 --port 30331 --rpc-port 9934 --name alice --chain rococo-local.json"
+    command: bash -c "/polkadot --unsafe-rpc-external --allow-private-ipv4 --rpc-cors all --wasm-execution Compiled --rpc-external --rpc-methods Unsafe -d /cumulus_relay/bob --validator --bob --rpc-port 9944 --port 30331 --rpc-port 9934 --name alice --chain rococo-local.json"
     volumes:
       - ./imbue_db/cumulus_relay:/cumulus_relay/
 
@@ -29,7 +29,7 @@ services:
       - "9917:9934"
       - "9918:9944"
       - "30303:30331"
-    command: bash -c "/polkadot --unsafe-ws-external --allow-private-ipv4 --rpc-cors all --wasm-execution Compiled --rpc-external --rpc-methods Unsafe -d /cumulus_relay/charlie --validator --charlie --ws-port 9944 --port 30331 --rpc-port 9934 --name alice --chain rococo-local.json"
+    command: bash -c "/polkadot --unsafe-rpc-external --allow-private-ipv4 --rpc-cors all --wasm-execution Compiled --rpc-external --rpc-methods Unsafe -d /cumulus_relay/charlie --validator --charlie --rpc-port 9944 --port 30331 --rpc-port 9934 --name alice --chain rococo-local.json"
     volumes:
       - ./imbue_db/cumulus_relay:/cumulus_relay/
 
@@ -43,7 +43,7 @@ services:
       - "9980:9930"
       - "30333:30333"
       - "30334:30334"
-    command: bash -c "wget https://raw.githubusercontent.com/ImbueNetwork/imbue/main/res/imbue-raw.json;/imbue  --collator --allow-private-ipv4 --unsafe-ws-external --log=parity_ws::io=debug  --rpc-cors=all --rpc-external --rpc-methods=Unsafe -d /cumulus_parachain/imbue-1  --name imbue-collator-1 --ws-port 9942 --rpc-port 9930 --parachain-id 2121 --chain imbue-raw.json --execution=wasm --prometheus-external --port 30333 --  --port 30334 --chain rococo-local.json --execution=wasm --prometheus-external --ws-max-connections=200 --unsafe-pruning --pruning=1000"
+    command: bash -c "wget https://raw.githubusercontent.com/ImbueNetwork/imbue/main/res/imbue-raw.json;/imbue  --collator --allow-private-ipv4 --unsafe-rpc-external --log=parity_ws::io=debug  --rpc-cors=all --rpc-external --rpc-methods=Unsafe -d /cumulus_parachain/imbue-1  --name imbue-collator-1 --rpc-port 9942  --parachain-id 2121 --chain imbue-raw.json --execution=wasm --prometheus-external --port 30333 --  --port 30334 --chain rococo-local.json --execution=wasm --prometheus-external --rpc-max-connections=200 --unsafe-pruning --pruning=1000"
     volumes:
       - ./imbue_db/cumulus_parachain_1:/cumulus_parachain/
 
@@ -57,7 +57,7 @@ services:
       - "9981:9930"
       - "30335:30335"
       - "30336:30336"
-    command: bash -c "wget https://raw.githubusercontent.com/ImbueNetwork/imbue/main/res/imbue-raw.json;/imbue  --collator --allow-private-ipv4 --unsafe-ws-external --rpc-cors=all --rpc-external --rpc-methods=Unsafe -d /cumulus_parachain/imbue-1  --name imbue-collator-1 --ws-port 9942 --rpc-port 9930 --parachain-id 2121 --chain imbue-raw.json --execution=wasm --prometheus-external --port 30335 --  --port 30336 --chain rococo-local.json --execution=wasm --prometheus-external --unsafe-pruning --pruning=1000"
+    command: bash -c "wget https://raw.githubusercontent.com/ImbueNetwork/imbue/main/res/imbue-raw.json;/imbue  --collator --allow-private-ipv4 --unsafe-rpc-external --rpc-cors=all --rpc-external --rpc-methods=Unsafe -d /cumulus_parachain/imbue-1  --name imbue-collator-1 --rpc-port 9942  --parachain-id 2121 --chain imbue-raw.json --execution=wasm --prometheus-external --port 30335 --  --port 30336 --chain rococo-local.json --execution=wasm --prometheus-external --unsafe-pruning --pruning=1000"
     volumes:
       - ./imbue_db/cumulus_parachain_2:/cumulus_parachain/
       
@@ -71,7 +71,7 @@ services:
       - "9982:9930"
       - "30337:30337"
       - "30338:30338"
-    command: bash -c "wget https://raw.githubusercontent.com/ImbueNetwork/imbue/main/res/imbue-raw.json;/imbue --log=parity_ws::io=debug  --collator --allow-private-ipv4 --unsafe-ws-external --rpc-cors=all --rpc-external --rpc-methods=Unsafe -d /cumulus_parachain/imbue-1  --name imbue-collator-1 --ws-port 9942 --rpc-port 9930 --parachain-id 2121 --chain imbue-raw.json --execution=wasm --prometheus-external --port 30337 --  --port 30338 --chain rococo-local.json --execution=wasm --prometheus-external --unsafe-pruning --pruning=1000"
+    command: bash -c "wget https://raw.githubusercontent.com/ImbueNetwork/imbue/main/res/imbue-raw.json;/imbue --log=parity_ws::io=debug  --collator --allow-private-ipv4 --unsafe-rpc-external --rpc-cors=all --rpc-external --rpc-methods=Unsafe -d /cumulus_parachain/imbue-1  --name imbue-collator-1 --rpc-port 9942  --parachain-id 2121 --chain imbue-raw.json --execution=wasm --prometheus-external --port 30337 --  --port 30338 --chain rococo-local.json --execution=wasm --prometheus-external --unsafe-pruning --pruning=1000"
     volumes:
       - ./imbue_db/cumulus_parachain_3:/cumulus_parachain/
 

--- a/scripts/polkadot-launch/imbueLaunchConfig.js
+++ b/scripts/polkadot-launch/imbueLaunchConfig.js
@@ -13,7 +13,7 @@ const parachainAlicePrometheusPort = 9610;
 
 const commonFlags = [
     "--force-authoring",
-    "--unsafe-ws-external",
+    "--unsafe-rpc-external",
     "--rpc-cors=all",
     "--rpc-external",
     "--rpc-methods=Unsafe",
@@ -32,7 +32,7 @@ const parachainNodeFlags = [
     "--",
     "--prometheus-external",
     "--ws-max-out-buffer-capacity=99999",
-    "--ws-max-connections=200"
+    "--rpc-max-connections=200"
 ];
 
 const relaychain = {


### PR DESCRIPTION
cli args have been updated based on this [release](https://github.com/paritytech/polkadot/releases/tag/v0.9.43), specifically this [pr](https://github.com/paritytech/substrate/pull/13384)

summary is below

```
--rpc--max--payload (replaced by --rpc--max-request-size and --rpc-max-response-size)
--ws--max--out-buffer-capacity
--ws-external (replaced by --rpc_external)
--unsafe--ws--external (replaced by --unsafe-rpc-external)
--ipc--path
--ws-port (replaced by --rpc--port)
--ws-max--connections (replaced by --rpc--max--connections)
--rpc-http (replaced by --rpc-addr)
--rpc-ws (replaced by --rpc-addr)
```