### PR TITLE
Create a staging branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - main
+      - staging
     paths-ignore:
       - "**.md"
   pull_request:
     branches:
       - main
+      - staging
     paths-ignore:
       - "**.md"
 env:
@@ -16,6 +18,15 @@ env:
   GCP_ZONE: europe-west3-a
 
 jobs:
+  check_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch
+        if: github.base_ref == 'main' && github.head_ref != 'staging'
+        run: |
+          echo "ERROR: You can only merge to main from staging."
+          exit 1
+
   create-runner:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - staging
     paths-ignore:
       - "**.md"
   pull_request:


### PR DESCRIPTION
Since im struggling to keep track of everything, all changes go to the branch `staging` and when we do a runtime upgrade we do a PR to `main`.

So during development 
`new_changes_1 ->  staging`
`new_changes_2 ->  staging`

Ready for runtime upgrade
`staging -> main`

This allows us to do things like check the spec_version, benchmarks and migrations etc systematically before an upgrade.