### PR TITLE
Optional fellowship switch

### DIFF
--- a/pallets/briefs/src/benchmarking.rs
+++ b/pallets/briefs/src/benchmarking.rs
@@ -41,6 +41,7 @@ mod benchmarks {
             brief_id,
             CurrencyId::Native,
             milestones,
+            false,
         );
         assert_last_event::<T>(Event::<T>::BriefSubmitted(caller, brief_id).into());
     }
@@ -63,7 +64,8 @@ mod benchmarks {
             initial_contribution,
             brief_id,
             CurrencyId::Native,
-            milestones
+            milestones,
+            false,
         ));
         let brief_owner: T::AccountId = brief_owners[0].clone();
         // (brief_owner, brief_id, contribution)
@@ -93,7 +95,8 @@ mod benchmarks {
             initial_contribution,
             brief_id,
             CurrencyId::Native,
-            milestones
+            milestones,
+            false,
         ));
         // (origin, brief_id)
         #[extrinsic_call]
@@ -118,7 +121,8 @@ mod benchmarks {
             initial_contribution,
             brief_id,
             CurrencyId::Native,
-            milestones
+            milestones,
+            false,
         ));
         // (origin, brief_id)
         #[extrinsic_call]

--- a/pallets/briefs/src/integration_tests.rs
+++ b/pallets/briefs/src/integration_tests.rs
@@ -22,6 +22,7 @@ fn create_proposal_from_brief() {
             brief_id,
             CurrencyId::Native,
             get_milestones(10),
+            false,
         );
 
         assert_ok!(BriefsMod::commence_work(

--- a/pallets/briefs/src/lib.rs
+++ b/pallets/briefs/src/lib.rs
@@ -31,10 +31,10 @@ pub mod pallet {
     use frame_system::pallet_prelude::*;
     use orml_traits::{MultiCurrency, MultiReservableCurrency};
     use pallet_deposits::traits::DepositHandler;
+    use pallet_fellowship::traits::EnsureRole;
     use pallet_fellowship::traits::SelectJury;
     use pallet_proposals::traits::IntoProposal;
     use pallet_proposals::{Contribution, FundingPath, ProposedMilestone};
-    use pallet_fellowship::traits::EnsureRole;
     use sp_arithmetic::per_things::Percent;
     use sp_core::H256;
     use sp_runtime::traits::Zero;
@@ -91,7 +91,6 @@ pub mod pallet {
         type EnsureRole: pallet_fellowship::traits::EnsureRole<AccountIdOf<Self>>;
         /// The weight info for the extrinsics.
         type WeightInfo: WeightInfoT;
-
     }
 
     #[pallet::storage]

--- a/pallets/briefs/src/mock.rs
+++ b/pallets/briefs/src/mock.rs
@@ -18,13 +18,13 @@ use sp_runtime::{
 };
 
 use pallet_deposits::traits::DepositHandler;
+use pallet_fellowship::traits::FellowshipHandle;
+use pallet_fellowship::Role;
 use sp_std::{
     convert::{TryFrom, TryInto},
     str,
     vec::Vec,
 };
-use pallet_fellowship::Role;
-use pallet_fellowship::traits::FellowshipHandle;
 
 type Block = frame_system::mocking::MockBlock<Test>;
 pub type BlockNumber = u64;
@@ -297,7 +297,6 @@ impl pallet_fellowship::Config for Test {
     type Permissions = pallet_fellowship::impls::VetterAndFreelancerAllPermissions;
     type WeightInfo = pallet_fellowship::weights::WeightInfo<Test>;
 }
-
 
 parameter_types! {
     pub const UnitWeightCost: u64 = 10;

--- a/pallets/briefs/src/mock.rs
+++ b/pallets/briefs/src/mock.rs
@@ -23,6 +23,8 @@ use sp_std::{
     str,
     vec::Vec,
 };
+use pallet_fellowship::Role;
+use pallet_fellowship::traits::FellowshipHandle;
 
 type Block = frame_system::mocking::MockBlock<Test>;
 pub type BlockNumber = u64;
@@ -57,6 +59,7 @@ frame_support::construct_runtime!(
         BriefsMod: pallet_briefs::{Pallet, Call, Storage, Event<T>},
         Proposals: pallet_proposals::{Pallet, Call, Storage, Event<T>},
         Identity: pallet_identity::{Pallet, Call, Storage, Event<T>},
+        Fellowship: pallet_fellowship::{Pallet, Call, Storage, Event<T>},
     }
 );
 
@@ -209,6 +212,7 @@ impl pallet_briefs::Config for Test {
     type DepositHandler = MockDepositHandler;
     type WeightInfo = pallet_briefs::WeightInfo<Self>;
     type JurySelector = MockJurySelector;
+    type EnsureRole = pallet_fellowship::impls::EnsureFellowshipRole<Self>;
 }
 
 parameter_types! {
@@ -274,12 +278,36 @@ impl pallet_identity::Config for Test {
 }
 
 parameter_types! {
+    pub MaxCandidatesPerShortlist: u32 = 100;
+    pub ShortlistPeriod: BlockNumber = 100;
+    pub MembershipDeposit: Balance = 50_000_000;
+    pub SlashAccount: AccountId = 1;
+    pub DepositCurrencyId: CurrencyId = CurrencyId::Native;
+}
+
+impl pallet_fellowship::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+    type MultiCurrency = Tokens;
+    type ForceAuthority = EnsureRoot<AccountId>;
+    type MaxCandidatesPerShortlist = MaxCandidatesPerShortlist;
+    type ShortlistPeriod = ShortlistPeriod;
+    type MembershipDeposit = MembershipDeposit;
+    type DepositCurrencyId = DepositCurrencyId;
+    type SlashAccount = SlashAccount;
+    type Permissions = pallet_fellowship::impls::VetterAndFreelancerAllPermissions;
+    type WeightInfo = pallet_fellowship::weights::WeightInfo<Test>;
+}
+
+
+parameter_types! {
     pub const UnitWeightCost: u64 = 10;
     pub const MaxInstructions: u32 = 100;
 }
+
 pub static ALICE: AccountId = 125;
 pub static BOB: AccountId = 126;
 pub static CHARLIE: AccountId = 127;
+pub static FREELANCER: AccountId = 1270;
 pub static TREASURY: AccountId = 200;
 
 pub(crate) fn build_test_externality() -> sp_io::TestExternalities {
@@ -292,7 +320,7 @@ pub(crate) fn build_test_externality() -> sp_io::TestExternalities {
         .unwrap();
     orml_tokens::GenesisConfig::<Test> {
         balances: {
-            vec![ALICE, BOB, CHARLIE]
+            vec![ALICE, BOB, CHARLIE, FREELANCER]
                 .into_iter()
                 .map(|id| (id, CurrencyId::Native, 1000000))
                 .collect::<Vec<_>>()
@@ -303,6 +331,7 @@ pub(crate) fn build_test_externality() -> sp_io::TestExternalities {
 
     let mut ext = sp_io::TestExternalities::new(t);
     ext.execute_with(|| {
+        pallet_fellowship::Roles::<Test>::insert(&FREELANCER, (Role::Freelancer, 10));
         System::set_block_number(1);
     });
     ext

--- a/pallets/briefs/src/tests.rs
+++ b/pallets/briefs/src/tests.rs
@@ -6,10 +6,10 @@ use crate::*;
 use common_types::CurrencyId;
 use frame_support::{assert_noop, assert_ok, pallet_prelude::*};
 use orml_traits::{MultiCurrency, MultiReservableCurrency};
+use pallet_fellowship::traits::EnsureRole;
 use pallet_proposals::{BoundedProposedMilestones, Projects, ProposedMilestone};
 use sp_arithmetic::per_things::Percent;
 use sp_runtime::DispatchError::BadOrigin;
-use pallet_fellowship::traits::EnsureRole;
 
 use std::convert::TryInto;
 
@@ -36,24 +36,25 @@ fn create_brief_not_approved_applicant() {
 #[test]
 fn create_brief_approved_applicant() {
     build_test_externality().execute_with(|| {
-        assert_ok!(<Test as Config>::EnsureRole::ensure_role(&FREELANCER, pallet_fellowship::Role::Freelancer, None));
+        assert_ok!(<Test as Config>::EnsureRole::ensure_role(
+            &FREELANCER,
+            pallet_fellowship::Role::Freelancer,
+            None
+        ));
 
-         assert_ok!(
-             BriefsMod::create_brief(
-                 RuntimeOrigin::signed(BOB),
-                 get_brief_owners(10),
-                 FREELANCER,
-                 100000,
-                 10000,
-                 gen_hash(1),
-                 CurrencyId::Native,
-                 get_milestones(10),
-                 true,
-             )
-         );
+        assert_ok!(BriefsMod::create_brief(
+            RuntimeOrigin::signed(BOB),
+            get_brief_owners(10),
+            FREELANCER,
+            100000,
+            10000,
+            gen_hash(1),
+            CurrencyId::Native,
+            get_milestones(10),
+            true,
+        ));
     });
 }
-
 
 #[test]
 fn create_brief_brief_owner_overflow() {

--- a/pallets/briefs/src/tests.rs
+++ b/pallets/briefs/src/tests.rs
@@ -8,16 +8,52 @@ use frame_support::{assert_noop, assert_ok, pallet_prelude::*};
 use orml_traits::{MultiCurrency, MultiReservableCurrency};
 use pallet_proposals::{BoundedProposedMilestones, Projects, ProposedMilestone};
 use sp_arithmetic::per_things::Percent;
+use sp_runtime::DispatchError::BadOrigin;
+use pallet_fellowship::traits::EnsureRole;
 
 use std::convert::TryInto;
 
 #[test]
 fn create_brief_not_approved_applicant() {
     build_test_externality().execute_with(|| {
-        // TODO:
-        // Only accounts in the fellowship can apply for work
+        assert_noop!(
+            BriefsMod::create_brief(
+                RuntimeOrigin::signed(BOB),
+                get_brief_owners(u32::MAX),
+                ALICE,
+                100000,
+                10000,
+                gen_hash(1),
+                CurrencyId::Native,
+                get_milestones(10),
+                true,
+            ),
+            BadOrigin
+        );
     });
 }
+
+#[test]
+fn create_brief_approved_applicant() {
+    build_test_externality().execute_with(|| {
+        assert_ok!(<Test as Config>::EnsureRole::ensure_role(&FREELANCER, pallet_fellowship::Role::Freelancer, None));
+
+         assert_ok!(
+             BriefsMod::create_brief(
+                 RuntimeOrigin::signed(BOB),
+                 get_brief_owners(10),
+                 FREELANCER,
+                 100000,
+                 10000,
+                 gen_hash(1),
+                 CurrencyId::Native,
+                 get_milestones(10),
+                 true,
+             )
+         );
+    });
+}
+
 
 #[test]
 fn create_brief_brief_owner_overflow() {
@@ -32,6 +68,7 @@ fn create_brief_brief_owner_overflow() {
                 gen_hash(1),
                 CurrencyId::Native,
                 get_milestones(10),
+                false,
             ),
             Error::<Test>::TooManyBriefOwners
         );
@@ -50,6 +87,7 @@ fn create_brief_with_no_contribution_ok() {
             gen_hash(1),
             CurrencyId::Native,
             get_milestones(10),
+            false,
         ));
     });
 }
@@ -70,6 +108,7 @@ fn create_brief_no_contribution_and_contribute() {
             brief_id,
             CurrencyId::Native,
             get_milestones(10),
+            false,
         ));
 
         (0..5).for_each(|_| {
@@ -111,6 +150,7 @@ fn contribute_to_brief_not_brief_owner() {
             brief_id,
             CurrencyId::Native,
             get_milestones(10),
+            false,
         ));
 
         assert_noop!(
@@ -139,6 +179,7 @@ fn contribute_to_brief_more_than_total_ok() {
             brief_id,
             CurrencyId::Native,
             get_milestones(10),
+            false,
         ));
         assert_ok!(BriefsMod::contribute_to_brief(
             RuntimeOrigin::signed(BOB),
@@ -163,6 +204,7 @@ fn create_brief_already_exists() {
             brief_id,
             CurrencyId::Native,
             get_milestones(10),
+            false,
         ));
 
         assert_noop!(
@@ -175,6 +217,7 @@ fn create_brief_already_exists() {
                 brief_id,
                 CurrencyId::Native,
                 get_milestones(10),
+                false,
             ),
             Error::<Test>::BriefAlreadyExists
         );
@@ -196,6 +239,7 @@ fn only_applicant_can_start_work() {
             brief_id,
             CurrencyId::Native,
             get_milestones(10),
+            false,
         ));
 
         assert_noop!(
@@ -225,6 +269,7 @@ fn initial_contribution_and_extra_contribution_aggregates() {
             brief_id,
             CurrencyId::Native,
             get_milestones(10),
+            false,
         ));
 
         assert_ok!(BriefsMod::contribute_to_brief(
@@ -261,6 +306,7 @@ fn reserved_funds_are_transferred_to_project_kitty() {
             brief_id,
             CurrencyId::Native,
             get_milestones(10),
+            false,
         );
 
         assert_ok!(BriefsMod::commence_work(
@@ -293,6 +339,7 @@ fn cancel_brief_works() {
             brief_id,
             CurrencyId::Native,
             get_milestones(10),
+            false,
         ));
 
         assert_ok!(BriefsMod::contribute_to_brief(
@@ -359,6 +406,7 @@ fn cancel_brief_not_brief_owner() {
             brief_id,
             CurrencyId::Native,
             get_milestones(10),
+            false,
         ));
 
         assert_noop!(

--- a/pallets/fellowship/src/impls.rs
+++ b/pallets/fellowship/src/impls.rs
@@ -8,7 +8,7 @@ use sp_std::{vec, vec::Vec};
 /// Ensure that a account is of a given role.
 /// Used in other pallets like an ensure origin.
 pub struct EnsureFellowshipRole<T>(T);
-impl<T: Config> EnsureRole<AccountIdOf<T>, Role> for EnsureFellowshipRole<T> {
+impl<T: Config> EnsureRole<AccountIdOf<T>> for EnsureFellowshipRole<T> {
     type Success = ();
 
     fn ensure_role(

--- a/pallets/fellowship/src/traits.rs
+++ b/pallets/fellowship/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::Rank;
+use crate::{Rank, Role};
 use codec::{FullCodec, FullEncode};
 use frame_support::{pallet_prelude::*, weights::Weight};
 use sp_runtime::DispatchError;
@@ -19,7 +19,7 @@ pub trait FellowshipHandle<AccountId> {
     fn revoke_fellowship(who: &AccountId, slash_deposit: bool) -> Result<(), DispatchError>;
 }
 
-pub trait EnsureRole<AccountId, Role> {
+pub trait EnsureRole<AccountId> {
     type Success;
     fn ensure_role(
         acc: &AccountId,

--- a/runtime/imbue-kusama/src/lib.rs
+++ b/runtime/imbue-kusama/src/lib.rs
@@ -867,6 +867,7 @@ impl pallet_briefs::Config for Runtime {
     type BriefStorageItem = BriefStorageItem;
     type DepositHandler = Deposits;
     type JurySelector = PointerBasedJurySelector<Runtime>;
+    type EnsureRole = pallet_fellowship::impls::EnsureFellowshipRole<Runtime>;
 }
 
 parameter_types! {


### PR DESCRIPTION

solves: https://github.com/ImbueNetwork/imbue/issues/192

### API changes
You now have to pass in wether you need the applicant to be a Role::Freelancer.
It will check `pallet_fellowship` to see wether this is the case.

```rust
pub fn create_brief(
            origin: OriginFor<T>,
            mut brief_owners: BoundedBriefOwners<T>,
            applicant: AccountIdOf<T>,
            budget: BalanceOf<T>,
            initial_contribution: BalanceOf<T>,
            brief_id: BriefHash,
            currency_id: CurrencyId,
            milestones: BoundedProposedMilestones<T>,
            require_fellowship: bool,
        ) -> DispatchResult
```

### Migrations
No migrations needed, since applicant is checked on creation there is no need to save it to the brief type.
